### PR TITLE
Specify the types of left and right multipliers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,7 @@ version = "0.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"
 
 [compat]
 julia = "1"
-
-

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\Chien\\.julia\\dev\\ConvolutionOperators"
+}

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "c:\\Users\\Chien\\.julia\\dev\\ConvolutionOperators"
-}

--- a/src/leftrightmul.jl
+++ b/src/leftrightmul.jl
@@ -23,8 +23,11 @@ function Base.size(x::LeftRightMulCVO,i) size(x)[i] end
 function Base.axes(x::LeftRightMulCVO) map(Base.OneTo, size(x)) end
 function Base.axes(x::LeftRightMulCVO, i) axes(x)[i] end
 
-function Base.:*(C::AbstractConvOp, B) LeftRightMulCVO(C,I,B) end
-function Base.:*(A, C::AbstractConvOp) LeftRightMulCVO(C,A,I) end
+function Base.:*(C::AbstractConvOp, B::LinearMap) LeftRightMulCVO(C,I,B) end
+function Base.:*(A::LinearMap, C::AbstractConvOp) LeftRightMulCVO(C,A,I) end
+
+function Base.:*(C::AbstractConvOp, B::AbstractArray) C * LinearMap(B) end
+function Base.:*(A::AbstractArray, C::AbstractConvOp) LinearMap(B) * C end
 
 function convolve!(y, Z::LeftRightMulCVO, x, X, j, k_start=1, k_stop=size(Z,3))
 

--- a/src/leftrightmul.jl
+++ b/src/leftrightmul.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra
+using LinearAlgebra, LinearMaps
 
 struct LeftRightMulCVO <: AbstractConvOp
     convop
@@ -26,8 +26,8 @@ function Base.axes(x::LeftRightMulCVO, i) axes(x)[i] end
 function Base.:*(C::AbstractConvOp, B::LinearMap) LeftRightMulCVO(C,I,B) end
 function Base.:*(A::LinearMap, C::AbstractConvOp) LeftRightMulCVO(C,A,I) end
 
-function Base.:*(C::AbstractConvOp, B::AbstractArray) C * LinearMap(B) end
-function Base.:*(A::AbstractArray, C::AbstractConvOp) LinearMap(B) * C end
+function Base.:*(C::AbstractConvOp, B::AbstractArray) LeftRightMulCVO(C,I,B) end
+function Base.:*(A::AbstractArray, C::AbstractConvOp) LeftRightMulCVO(C,A,I) end
 
 function convolve!(y, Z::LeftRightMulCVO, x, X, j, k_start=1, k_stop=size(Z,3))
 


### PR DESCRIPTION
We can not convert the type of right_linear_map from AbstractArray to LinearMap since it will raise an error with the view function in the convolve! (file liftedconvop.jl)